### PR TITLE
Allow useId in server and shared components

### DIFF
--- a/.changeset/fast-tomatoes-hang.md
+++ b/.changeset/fast-tomatoes-hang.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-react-server-components": patch
+---
+
+Allow `useId` in server and shared components.

--- a/src/rules/use-client.test.ts
+++ b/src/rules/use-client.test.ts
@@ -156,6 +156,13 @@ const Button = () => {
   return <div />;
 }`,
         },
+        {
+          code: `import {useId} from 'react';
+const Button = () => {
+  const id = useId();
+  return <div id={id} />;
+}`,
+        },
       ],
       invalid: [
         {
@@ -207,6 +214,21 @@ import {useEffect} from 'react';
 const Button = () => {
   useEffect(() => {}, [])
   return <div />;
+}`,
+        },
+        {
+          code: `const Button = () => {
+  const id = useIdentifier();
+  return <div id={id} />;
+}`,
+          errors: [
+            { messageId: "addUseClientHooks", data: { hook: "useIdentifier" } },
+          ],
+          output: `'use client';
+
+const Button = () => {
+  const id = useIdentifier();
+  return <div id={id} />;
 }`,
         },
       ],

--- a/src/rules/use-client.ts
+++ b/src/rules/use-client.ts
@@ -16,7 +16,6 @@ import Components from "eslint-plugin-react/lib/util/Components";
 // @ts-expect-error
 import componentUtil from "eslint-plugin-react/lib/util/componentUtil";
 
-const HOOK_REGEX = /^use[A-Z]/;
 const useClientRegex = /^('|")use client('|")/;
 const browserOnlyGlobals = Object.keys(globals.browser)
   .reduce<Set<Exclude<keyof typeof globals.browser, keyof typeof globals.node>>>(
@@ -161,7 +160,7 @@ const create = Components.detect(
         }
 
         if (
-          HOOK_REGEX.test(name) &&
+          isClientOnlyHook(name) &&
           // Is in a function...
           context.getScope().type === "function" &&
           // But only if that function is a component
@@ -206,7 +205,7 @@ const create = Components.detect(
 
         if (
           expression.callee &&
-          HOOK_REGEX.test(expression.callee.name) &&
+          isClientOnlyHook(expression.callee.name) &&
           Boolean(util.getParentComponent(expression))
         ) {
           instances.push(expression.callee.name);
@@ -292,6 +291,11 @@ function isFunction(def: any) {
     return true;
   }
   return false;
+}
+
+function isClientOnlyHook(name: string) {
+  // `useId` is the only hook that's allowed in server components
+  return /^use[A-Z]/.test(name) && name !== 'useId'
 }
 
 export const ClientComponents = { meta, create };


### PR DESCRIPTION
## Context

The `useId` hook is the only hook that is allowed in client, server and shared components, which means it doesn't require the `use client` directive. From the [React docs](https://react.dev/reference/react/use-client#using-third-party-libraries):

> Third-party components that use any of the following React APIs must run on the client:
> 
> - [...]
> - [`react`](https://react.dev/reference/react/hooks) and [`react-dom`](https://react.dev/reference/react-dom/hooks) Hooks, excluding [`use`](https://react.dev/reference/react/use) and [`useId`](https://react.dev/reference/react/useId)

## Changes 

- Add an exception for `useId`. Initially, I tried to amend the regular expression, but a simple string comparison seemed simpler and more performant.