### PR TITLE
Allow useMemo hook in server components

### DIFF
--- a/.changeset/loud-terms-confess.md
+++ b/.changeset/loud-terms-confess.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-react-server-components": minor
+---
+
+allow useMemo hook in RSC

--- a/src/rules/use-client.test.ts
+++ b/src/rules/use-client.test.ts
@@ -171,6 +171,36 @@ export function Foo() {
 }`,
           options: [{ allowedServerHooks: ["useTranslations"] }],
         },
+        {
+          code: `import React from 'react';
+export function Foo({id}) {
+  const t = React.useState(id);
+  return <button id={t} />;
+}`,
+          options: [{ allowedServerHooks: ["useState"] }],
+        },
+        {
+          code: `import * as React from 'react';
+export function Foo({id}) {
+  const t = React.useState(id);
+  return <button id={t} />;
+}`,
+          options: [{ allowedServerHooks: ["useState"] }],
+        },
+        {
+          code: `import {useMemo} from 'react';
+const Button = ({id}) => {
+  const memoizedId = useMemo(() => id, [id]);
+  return <div id={memoizedId} />;
+}`,
+        },
+        {
+          code: `import React from 'react';
+const Button = ({id}) => {
+  const memoizedId = React.useMemo(() => id, [id]);
+  return <div id={memoizedId} />;
+}`,
+        },
       ],
       invalid: [
         {

--- a/src/rules/use-client.ts
+++ b/src/rules/use-client.ts
@@ -81,9 +81,8 @@ const create = Components.detect(
     function isClientOnlyHook(name: string) {
       return (
         // `useId` is the only hook that's allowed in server components
-        name !== "useId" &&
         !(options.allowedServerHooks || []).includes(name) &&
-        /^use[A-Z]/.test(name)
+        /^use(?!(Id|Memo)$)[A-Z]/.test(name)
       );
     }
 


### PR DESCRIPTION
The `useMemo` hook is allowed for use in RSC, although this is not written in the official documentation. 
An example of using this hook in RSC can be found [here](https://github.com/vercel/react-tweet/blob/3367f07a2177462af1d05d62b1785bb9aa4ab787/packages/react-tweet/src/twitter-theme/embedded-tweet.tsx#L21-L22).