### PR TITLE
feat: make module window check more robust

### DIFF
--- a/.changeset/honest-peas-peel.md
+++ b/.changeset/honest-peas-peel.md
@@ -2,4 +2,14 @@
 "eslint-plugin-react-server-components": minor
 ---
 
-Making window check more robust to not require "use client" when safely accessed behind a `typeof window !== undefined` check
+Making checks for window usage more robust to not require "use client" when safely accessed behind a `typeof window !== 'undefined'` or `typeof document !== 'undefined'`check.
+
+For example:
+```
+const HREF = typeof window !== 'undefined' ? window.location.href : '';
+
+const MyComponent = () => {
+    return <div>{HREF}</div>;
+}
+```
+does not need to be marked with a "use client" because all of it's client only actions are behind a server check.

--- a/.changeset/honest-peas-peel.md
+++ b/.changeset/honest-peas-peel.md
@@ -1,5 +1,5 @@
 ---
-"eslint-plugin-react-server-components": patch
+"eslint-plugin-react-server-components": minor
 ---
 
 Making window check more robust to not require "use client" when safely accessed behind a `typeof window !== undefined` check

--- a/.changeset/honest-peas-peel.md
+++ b/.changeset/honest-peas-peel.md
@@ -1,15 +1,15 @@
 ---
-"eslint-plugin-react-server-components": minor
+"eslint-plugin-react-server-components": major
 ---
 
-Making checks for window usage more robust to not require "use client" when safely accessed behind a `typeof window !== 'undefined'` or `typeof document !== 'undefined'`check.
+Makes checks for window usage more robust to not require "use client" when safely accessed behind a `typeof window !== 'undefined'` or `typeof document !== 'undefined'`check.
 
 For example:
-```
-const HREF = typeof window !== 'undefined' ? window.location.href : '';
 
-const MyComponent = () => {
-    return <div>{HREF}</div>;
-}
+```jsx
+const href = typeof window !== 'undefined' ? window.location.href : '';
+
+const MyComponent = () => <div>{href}</div>;
 ```
-does not need to be marked with a "use client" because all of it's client only actions are behind a server check.
+
+This does not need to be marked with a "use client" because all of its client-only actions are behind a safety check.

--- a/.changeset/honest-peas-peel.md
+++ b/.changeset/honest-peas-peel.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-react-server-components": patch
+---
+
+Making window check more robust to not require "use client" when safely accessed behind a `typeof window !== undefined` check

--- a/src/rules/use-client.test.ts
+++ b/src/rules/use-client.test.ts
@@ -48,6 +48,13 @@ describe("use client", () => {
       return context;
     }`,
         },
+        {
+          code: `const HREF = typeof window === 'undefined' ? undefined : window.location.href;`
+        },
+        {
+          code: `const HREF = typeof window !== 'undefined' ? window.location.href : '';`
+        },
+
       ],
       invalid: [
         // DOCUMENT
@@ -99,6 +106,13 @@ function Bar() {
   window.addEventListener('scroll', () => {})
   return <div />;
 }`,
+        },
+        {
+          code: `const HREF = typeof window === 'undefined' ? window.location.href : window.location.href.slice(0,10);`,
+          errors: [{ messageId: "addUseClientBrowserAPI" }],
+          output: `'use client';
+
+const HREF = typeof window === 'undefined' ? window.location.href : window.location.href.slice(0,10);`,
         },
         // OBSERVERS
         {

--- a/src/rules/use-client.test.ts
+++ b/src/rules/use-client.test.ts
@@ -24,37 +24,22 @@ describe("use client", () => {
           code: 'const foo = "bar"',
         },
         {
-          code: `import {createContext, useContext, useEffect} from 'react';
-    const context = createContext()
-    export function useTheme() {
-      const context = useContext(context);
-      useEffect(() => {
-        window.setTimeout(() => {});
-      });
-      return context;
-    }`,
+          code: `const HREF = typeof window === 'undefined' ? undefined : window.location.href;`,
         },
         {
-          code: `import * as React from 'react';
-    const context = React.createContext()
-    export function Foo() {
-      return <div />;
-    }
-    export function useTheme() {
-      const context = React.useContext(context);
-      React.useEffect(() => {
-        window.setTimeout(() => {});
-      });
-      return context;
-    }`,
+          code: `const HREF = typeof window !== 'undefined' ? window.location.href : '';`,
         },
         {
-          code: `const HREF = typeof window === 'undefined' ? undefined : window.location.href;`
+          code: `const el = typeof document === 'undefined' ? undefined : document.createElement('element');`,
         },
         {
-          code: `const HREF = typeof window !== 'undefined' ? window.location.href : '';`
+          code: `const foo = "bar";
+function Bar() {
+  if(typeof document !== 'undefined')
+    document.addEventListener('scroll', () => {})
+  return <div />;
+}`,
         },
-
       ],
       invalid: [
         // DOCUMENT
@@ -108,11 +93,80 @@ function Bar() {
 }`,
         },
         {
+          code: `import {createContext, useContext, useEffect} from 'react';
+
+    const context = createContext()
+    export function useTheme() {
+      const context = useContext(context);
+      useEffect(() => {
+        window.setTimeout(() => {});
+      });
+      return context;
+    }`,
+          errors: [{ messageId: "addUseClientBrowserAPI" }],
+          output: `'use client';
+
+import {createContext, useContext, useEffect} from 'react';
+
+    const context = createContext()
+    export function useTheme() {
+      const context = useContext(context);
+      useEffect(() => {
+        window.setTimeout(() => {});
+      });
+      return context;
+    }`,
+        },
+        {
+          code: `import * as React from 'react';
+
+    const context = React.createContext()
+    export function Foo() {
+      return <div />;
+    }
+    export function useTheme() {
+      const context = React.useContext(context);
+      React.useEffect(() => {
+        window.setTimeout(() => {});
+      });
+      return context;
+    }`,
+          errors: [{ messageId: "addUseClientBrowserAPI" }],
+          output: `'use client';
+
+import * as React from 'react';
+
+    const context = React.createContext()
+    export function Foo() {
+      return <div />;
+    }
+    export function useTheme() {
+      const context = React.useContext(context);
+      React.useEffect(() => {
+        window.setTimeout(() => {});
+      });
+      return context;
+    }`,
+        },
+        {
           code: `const HREF = typeof window === 'undefined' ? window.location.href : window.location.href.slice(0,10);`,
           errors: [{ messageId: "addUseClientBrowserAPI" }],
           output: `'use client';
 
 const HREF = typeof window === 'undefined' ? window.location.href : window.location.href.slice(0,10);`,
+        },
+        {
+          code: `let HREF = '';
+    if (typeof window === 'undefined') {
+      HREF = window.location.href;
+    }`,
+          errors: [{ messageId: "addUseClientBrowserAPI" }],
+          output: `'use client';
+
+let HREF = '';
+    if (typeof window === 'undefined') {
+      HREF = window.location.href;
+    }`,
         },
         // OBSERVERS
         {

--- a/src/rules/use-client.ts
+++ b/src/rules/use-client.ts
@@ -27,8 +27,6 @@ const browserOnlyGlobals = Object.keys(globals.browser).reduce<
   return acc;
 }, new Set());
 
-const validGlobalsForServerChecks = new Set(["document", "window"]);
-
 type Options = [
   {
     allowedServerHooks?: string[];
@@ -116,34 +114,6 @@ const create = Components.detect(
       });
     }
 
-    function findFirstParentOfType(
-      node: Rule.Node,
-      type: string
-    ): Rule.Node | null {
-      let currentNode: Rule.Node | null = node;
-
-      while (currentNode) {
-        if (currentNode.type === type) {
-          return currentNode;
-        }
-        currentNode = currentNode?.parent;
-      }
-
-      return null;
-    }
-
-    function isNodeInTree(node: Rule.Node, target: Rule.Node): boolean {
-      let currentNode: Rule.Node | null = node;
-
-      while (currentNode) {
-        if (currentNode === target) {
-          return true;
-        }
-        currentNode = currentNode.parent;
-      }
-
-      return false;
-    }
 
     function getBinaryBranchExecutedOnServer(node: BinaryExpression): {
       isGlobalClientPropertyCheck: boolean;
@@ -153,7 +123,7 @@ const create = Components.detect(
         node.left?.type === "UnaryExpression" &&
         node.left.operator === "typeof" &&
         node.left.argument?.type === "Identifier" &&
-        validGlobalsForServerChecks.has(node.left.argument?.name) &&
+        browserOnlyGlobals.has(node.left.argument?.name as any) &&
         node.right?.type === "Literal" &&
         node.right.value === "undefined" &&
         (node.operator === "===" || node.operator === "!==");
@@ -408,6 +378,35 @@ function isFunction(def: any) {
   if (def.node.init && def.node.init.type === "ArrowFunctionExpression") {
     return true;
   }
+  return false;
+}
+
+function findFirstParentOfType(
+  node: Rule.Node,
+  type: string
+): Rule.Node | null {
+  let currentNode: Rule.Node | null = node;
+
+  while (currentNode) {
+    if (currentNode.type === type) {
+      return currentNode;
+    }
+    currentNode = currentNode?.parent;
+  }
+
+  return null;
+}
+
+function isNodeInTree(node: Rule.Node, target: Rule.Node): boolean {
+  let currentNode: Rule.Node | null = node;
+
+  while (currentNode) {
+    if (currentNode === target) {
+      return true;
+    }
+    currentNode = currentNode.parent;
+  }
+
   return false;
 }
 

--- a/src/rules/use-client.ts
+++ b/src/rules/use-client.ts
@@ -115,7 +115,6 @@ const create = Components.detect(
     }
 
     function getIsSafeWindowCheck(node: Rule.NodeParentExtension) {
-
       // check if the window usage is behind a typeof window === 'undefined' check
       const conditionalExpressionNode = node.parent?.parent;
       const isWindowCheck =
@@ -142,8 +141,7 @@ const create = Components.detect(
         (isNegatedWindowCheck &&
           conditionalExpressionNode.consequent === node?.parent);
 
-      return isSafelyBehindWindowCheck
-
+      return isSafelyBehindWindowCheck;
     }
 
     const reactImports: Record<string | "namespace", string | string[]> = {
@@ -243,9 +241,8 @@ const create = Components.detect(
         const scopeType = context.getScope().type;
 
         const isSafelyBehindWindowCheck = getIsSafeWindowCheck(node);
-        
 
-            if (
+        if (
           undeclaredReferences.has(name) &&
           browserOnlyGlobals.has(name) &&
           (scopeType === "module" || !!util.getParentComponent(node)) &&


### PR DESCRIPTION
We started using this rule in one of our repos (and are loving it so far!) and we noticed it was marking files that have patterns like this as needing the client directive 

```
const HREF = typeof window === 'undefined' ? undefined : window.location.href;
```

This is fine to execute on the server or the client because we are checking to make sure the window exists before accessing it. 

So I took a stab at updating the lint rule to account for this case. This is my first time dabbling in writing a lint rule, so please feel free to make suggestions! Overall we just want to get this case accounted for so we don't run into more issues with files being improperly marked 🙂 